### PR TITLE
Fix/android back-button / onboarding-screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In root directory: `yarn dev`
 
 ## Additional Dev-Info
 
-- Your Multisig address & biometrics wallet need a transaction to work correctly. E.g. by using the testnet faucet for biometrics wallet and then pressing "Prepare Multisig Wallet". Testnet faucet is located here: (https://discord.gg/juno)
-In order for the public key not to be null on chain, the account needs to act (like send funds). That’s what Prepare Multisig Wallet button does. Otherwise the nodes simply don’t know this necessary information about the address since it has done nothing.
+- The Multisig address & biometrics wallet need a transaction to work correctly. E.g. by using the testnet faucet for biometrics wallet and then pressing "Prepare Multisig Wallet". Testnet faucet is located here: (https://discord.gg/juno)
+In order for the public key not to be null on chain, the account needs to act (like send funds). That’s what "Prepare Multisig Wallet"-button does. Otherwise the nodes simply don’t know this necessary information about the address since it has done nothing.
 
-- Add prop initialRouteName="onboarding4" to Stack.Navigator in OnboardingScreen in obi-wallet/apps/mobile/src/app/screens/onboarding/index.tsx. (This basically skips the phone number key since it is not needed to reproduce the bug)
+- Add prop initialRouteName="onboarding4" to Stack.Navigator in OnboardingScreen in "obi-wallet/apps/mobile/src/app/screens/onboarding/index.tsx" to skip onboarding-screens

--- a/README.md
+++ b/README.md
@@ -33,3 +33,10 @@ In `obi-wallet` directory:
 ## Development workflow: browser extension
 
 In root directory: `yarn dev`
+
+## Additional Dev-Info
+
+- Your Multisig address & biometrics wallet need a transaction to work correctly. E.g. by using the testnet faucet for biometrics wallet and then pressing "Prepare Multisig Wallet". Testnet faucet is located here: (https://discord.gg/juno)
+In order for the public key not to be null on chain, the account needs to act (like send funds). That’s what Prepare Multisig Wallet button does. Otherwise the nodes simply don’t know this necessary information about the address since it has done nothing.
+
+- Add prop initialRouteName="onboarding4" to Stack.Navigator in OnboardingScreen in obi-wallet/apps/mobile/src/app/screens/onboarding/index.tsx. (This basically skips the phone number key since it is not needed to reproduce the bug)

--- a/obi-wallet/apps/mobile/src/app/button/icon-button.tsx
+++ b/obi-wallet/apps/mobile/src/app/button/icon-button.tsx
@@ -1,16 +1,13 @@
-import {
-  Platform,
-  TouchableNativeFeedback,
-  TouchableOpacity,
-  TouchableWithoutFeedbackProps,
-} from "react-native";
+import { TouchableOpacity, TouchableWithoutFeedbackProps } from "react-native";
 
 export type IconButtonProps = TouchableWithoutFeedbackProps;
 
 export function IconButton(props: IconButtonProps) {
-  if (Platform.OS === "ios") {
-    return <TouchableOpacity {...props} />;
-  } else {
-    return <TouchableNativeFeedback {...props} />;
-  }
+  return (
+    // icon-button doesnt work on Android, Android seems to work fine with "TouchableOpacity" in this case, but not with "TouchableNativeFeedback", Deleted Differenciation between OS (if/else), added a hitSlop for a nicer user experience and cleaned up the imports
+    <TouchableOpacity
+      {...props}
+      hitSlop={{ top: 15, bottom: 15, left: 15, right: 15 }}
+    />
+  );
 }

--- a/obi-wallet/apps/mobile/src/app/button/icon-button.tsx
+++ b/obi-wallet/apps/mobile/src/app/button/icon-button.tsx
@@ -4,7 +4,8 @@ export type IconButtonProps = TouchableWithoutFeedbackProps;
 
 export function IconButton(props: IconButtonProps) {
   return (
-    // icon-button doesnt work on Android, Android seems to work fine with "TouchableOpacity" in this case, but not with "TouchableNativeFeedback", Deleted Differenciation between OS (if/else), added a hitSlop for a nicer user experience and cleaned up the imports
+    // icon-button doesn't work on Android, Android seems to work fine with
+    // `TouchableOpacity` in this case, but not with `TouchableNativeFeedback`.
     <TouchableOpacity
       {...props}
       hitSlop={{ top: 15, bottom: 15, left: 15, right: 15 }}

--- a/obi-wallet/apps/mobile/src/app/screens/onboarding/onboarding2/index.tsx
+++ b/obi-wallet/apps/mobile/src/app/screens/onboarding/onboarding2/index.tsx
@@ -78,6 +78,7 @@ export const Onboarding2 = observer<Onboarding2Props>(({ navigation }) => {
           <View>
             <IconButton
               style={{
+                marginTop: 20,
                 marginLeft: -5,
                 padding: 5,
                 width: 25,

--- a/obi-wallet/apps/mobile/src/app/screens/onboarding/onboarding3/index.tsx
+++ b/obi-wallet/apps/mobile/src/app/screens/onboarding/onboarding3/index.tsx
@@ -48,6 +48,7 @@ export function Onboarding3({ navigation, route }: Onboarding3Props) {
           <View>
             <IconButton
               style={{
+                marginTop: 20,
                 marginLeft: -5,
                 padding: 5,
                 width: 25,

--- a/obi-wallet/apps/mobile/src/app/screens/onboarding/onboarding4/index.tsx
+++ b/obi-wallet/apps/mobile/src/app/screens/onboarding/onboarding4/index.tsx
@@ -58,6 +58,7 @@ export const Onboarding4 = observer<Onboarding4Props>(({ navigation }) => {
         <View>
           <IconButton
             style={{
+              marginTop: 20,
               marginLeft: -5,
               padding: 5,
               width: 25,

--- a/obi-wallet/apps/mobile/src/app/screens/onboarding/onboarding5/index.tsx
+++ b/obi-wallet/apps/mobile/src/app/screens/onboarding/onboarding5/index.tsx
@@ -131,6 +131,7 @@ export const Onboarding5 = observer<Onboarding5Props>(({ navigation }) => {
         <View>
           <IconButton
             style={{
+              marginTop: 20,
               marginLeft: -5,
               padding: 5,
               width: 25,


### PR DESCRIPTION
"icon-button" didn't work on Android (tested on emulator & phone), Android seems to work fine with "TouchableOpacity" in this case, but not with "TouchableNativeFeedback".

- Deleted differenciation between OS (if/else)
- Added a hitSlop for a nicer user experience
- Cleaned up the imports.
- Added marginTop on onboarding-screens
- Updated the README.md
