### PR TITLE
Fix back-buttons and receive-screen-button-bug

### DIFF
--- a/obi-wallet/apps/mobile/src/app/screens/components/back.tsx
+++ b/obi-wallet/apps/mobile/src/app/screens/components/back.tsx
@@ -10,7 +10,11 @@ export interface BackProps {
 export function Back({ style }: BackProps) {
   const { goBack } = useNavigation();
   return (
-    <TouchableHighlight onPress={goBack} style={style}>
+    <TouchableHighlight
+      onPress={goBack}
+      style={style}
+      hitSlop={{ top: 20, bottom: 20, left: 20, right: 20 }}
+    >
       <FontAwesomeIcon icon={faChevronLeft} style={{ color: "#7B87A8" }} />
     </TouchableHighlight>
   );

--- a/obi-wallet/apps/mobile/src/app/screens/receive/index.tsx
+++ b/obi-wallet/apps/mobile/src/app/screens/receive/index.tsx
@@ -38,7 +38,7 @@ export const ReceiveScreen = observer(() => {
         justifyContent: "space-between",
       }}
     >
-      <View>
+      <View style={{ zIndex: 2 }}>
         <View style={{ flexDirection: "row" }}>
           <Back style={{ alignSelf: "flex-start", zIndex: 2 }} />
           <Text


### PR DESCRIPTION
- Fixed back-buttons in main app
- Fixed "overlap"-bug for back-button on receive-screen (bottom-hitSlop was not working due to an overlap)