### PR TITLE
Fix/virtualised lists dropdown error

### DIFF
--- a/obi-wallet/apps/mobile/src/app/screens/components/phone-number/security-question-input.tsx
+++ b/obi-wallet/apps/mobile/src/app/screens/components/phone-number/security-question-input.tsx
@@ -61,6 +61,7 @@ export function SecurityQuestionInput({
         setOpen={setDropdownPickerOpen}
         setValue={onSecurityQuestionChange}
         setItems={setSecurityQuestions}
+        listMode="SCROLLVIEW"
       />
 
       <TextInput


### PR DESCRIPTION
**Fixed the error on onboarding2/Dropdown/Security-Question:**

Error:
<img width="286" alt="Screenshot 2022-09-14 at 07 52 10" src="https://user-images.githubusercontent.com/99530800/190070665-1dfb2ff1-2dc2-4204-bffb-4bfdfc88e7ef.png">

Solution:
The documentation says, that "_the FlatList component shouldn't be nested inside ScrollView or you'll come across the **VirtualizedLists should never be nested inside plain ScrollViews** warning._" As FlatList is the default setting in this case, it is suggested to use SCROLLVIEW mode".

<img width="274" alt="Screenshot 2022-09-14 at 07 56 23" src="https://user-images.githubusercontent.com/99530800/190071246-ef5adc3b-ca04-49ee-aa83-84df316a4802.png">

Seems to work!