### PR TITLE
Fix/phone country picker

### DIFF
--- a/obi-wallet/apps/mobile/src/app/phone-input/index.tsx
+++ b/obi-wallet/apps/mobile/src/app/phone-input/index.tsx
@@ -44,8 +44,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     fontSize: 14,
     fontWeight: 500,
-    paddingLeft: 20,
-    paddingRight: 20,
   },
   inputview: {
     flex: 1,
@@ -129,6 +127,7 @@ export function PhoneInput({
   const dark = false;
   const fontScaling = true;
   const disableNativeModal = false;
+  const preferredCountries = undefined; // ["US"]
 
   useEffect(() => {
     handlePhoneNumberCountryCode("+" + country.callingCode); // Pass country.callingcode back to parent component "onboarding2"
@@ -142,50 +141,46 @@ export function PhoneInput({
 
           <View style={styles.wholeview}>
             <TouchableOpacity style={styles.buttonview} onPress={switchVisible}>
-              <View
-                style={{ backgroundColor: "none", padding: 0, marginBottom: 5 }}
-              >
-                <CountryPicker
-                  theme={
-                    dark
-                      ? DARK_THEME
-                      : {
-                          primaryColor: "blue",
-                          primaryColorVariant: "#090816",
-                          backgroundColor: "#090816",
-                          onBackgroundTextColor: "#F6F5FF",
-                          fontSize: 14,
-                          filterPlaceholderTextColor: "#4B4E6E",
-                          activeOpacity: 0.7,
-                        }
-                  }
-                  {...{
-                    allowFontScaling: fontScaling,
-                    countryCode,
-                    withFilter,
-                    excludeCountries: ["AQ", "BV", "TF", "HM", "UM"], // No Calling-Code available
-                    withFlag,
-                    withCurrencyButton,
-                    withCallingCodeButton,
-                    withCountryNameButton,
-                    withAlphaFilter,
-                    withCallingCode,
-                    withCurrency,
-                    withEmoji,
-                    withModal,
-                    withFlagButton,
-                    onSelect,
-                    disableNativeModal,
-                    preferredCountries: ["US"],
-                    modalProps: {
-                      visible,
-                    },
-                    onClose: () => setVisible(false),
-                    onOpen: () => setVisible(true),
-                    translation: dropdownLanguage(currentLanguage),
-                  }}
-                />
-              </View>
+              <CountryPicker
+                theme={
+                  dark
+                    ? DARK_THEME
+                    : {
+                        primaryColor: "blue",
+                        primaryColorVariant: "#090816",
+                        backgroundColor: "#090816",
+                        onBackgroundTextColor: "#F6F5FF",
+                        fontSize: 14,
+                        filterPlaceholderTextColor: "#4B4E6E",
+                        activeOpacity: 0.7,
+                      }
+                }
+                {...{
+                  allowFontScaling: fontScaling,
+                  countryCode,
+                  withFilter,
+                  excludeCountries: ["AQ", "BV", "TF", "HM", "UM"], // No Calling-Code available
+                  withFlag,
+                  withCurrencyButton,
+                  withCallingCodeButton,
+                  withCountryNameButton,
+                  withAlphaFilter,
+                  withCallingCode,
+                  withCurrency,
+                  withEmoji,
+                  withModal,
+                  withFlagButton,
+                  onSelect,
+                  disableNativeModal,
+                  preferredCountries,
+                  modalProps: {
+                    visible,
+                  },
+                  onClose: () => setVisible(false),
+                  onOpen: () => setVisible(true),
+                  translation: dropdownLanguage(currentLanguage),
+                }}
+              />
             </TouchableOpacity>
 
             <View style={styles.inputview}>

--- a/obi-wallet/libs/common/src/languages/de.json
+++ b/obi-wallet/libs/common/src/languages/de.json
@@ -171,6 +171,6 @@
   "demo.demomode": "Demo Modus",
   "demo.enter": "Demo Modus Starten",
   "demo.info": "Du hast die App im Demo-Modus gestarted. Das erlaubt dir den Onboarding-Prozess mit irgendwelchen Fake-Daten abzuschließen.",
-  
+
   "phonecountrypicker.search.placeholder": "Land eingeben"
 }

--- a/obi-wallet/libs/common/src/languages/de.json
+++ b/obi-wallet/libs/common/src/languages/de.json
@@ -170,5 +170,7 @@
 
   "demo.demomode": "Demo Modus",
   "demo.enter": "Demo Modus Starten",
-  "demo.info": "Du hast die App im Demo-Modus gestarted. Das erlaubt dir den Onboarding-Prozess mit irgendwelchen Fake-Daten abzuschließen."
+  "demo.info": "Du hast die App im Demo-Modus gestarted. Das erlaubt dir den Onboarding-Prozess mit irgendwelchen Fake-Daten abzuschließen.",
+  
+  "phonecountrypicker.search.placeholder": "Land eingeben"
 }

--- a/obi-wallet/libs/common/src/languages/en.json
+++ b/obi-wallet/libs/common/src/languages/en.json
@@ -171,6 +171,6 @@
   "demo.demomode": "Demo Mode",
   "demo.enter": "Enter Demo Mode",
   "demo.info": "You have entered the app in demo mode. This allows you finish the onboarding process with any fake data.",
-  
+
   "phonecountrypicker.search.placeholder": "Enter country name"
 }

--- a/obi-wallet/libs/common/src/languages/en.json
+++ b/obi-wallet/libs/common/src/languages/en.json
@@ -170,5 +170,7 @@
 
   "demo.demomode": "Demo Mode",
   "demo.enter": "Enter Demo Mode",
-  "demo.info": "You have entered the app in demo mode. This allows you finish the onboarding process with any fake data."
+  "demo.info": "You have entered the app in demo mode. This allows you finish the onboarding process with any fake data.",
+  
+  "phonecountrypicker.search.placeholder": "Enter country name"
 }

--- a/obi-wallet/libs/common/src/languages/es.json
+++ b/obi-wallet/libs/common/src/languages/es.json
@@ -171,6 +171,6 @@
   "demo.demomode": "Demo Mode",
   "demo.enter": "Enter Demo Mode",
   "demo.info": "You have entered the app in demo mode. This allows you finish the onboarding process with any fake data.",
-  
+
   "phonecountrypicker.search.placeholder": "Enter country name"
 }

--- a/obi-wallet/libs/common/src/languages/es.json
+++ b/obi-wallet/libs/common/src/languages/es.json
@@ -170,5 +170,7 @@
 
   "demo.demomode": "Demo Mode",
   "demo.enter": "Enter Demo Mode",
-  "demo.info": "You have entered the app in demo mode. This allows you finish the onboarding process with any fake data."
+  "demo.info": "You have entered the app in demo mode. This allows you finish the onboarding process with any fake data.",
+  
+  "phonecountrypicker.search.placeholder": "Enter country name"
 }

--- a/obi-wallet/patches/react-native-country-picker-modal+2.0.0.patch
+++ b/obi-wallet/patches/react-native-country-picker-modal+2.0.0.patch
@@ -32,3 +32,20 @@ index 8816018..27c8f1f 100644
      },
      list: {
          flex: 1,
+diff --git a/node_modules/react-native-country-picker-modal/lib/FlagButton.js b/node_modules/react-native-country-picker-modal/lib/FlagButton.js
+index 7ad3e7b..30a3525 100644
+--- a/node_modules/react-native-country-picker-modal/lib/FlagButton.js
++++ b/node_modules/react-native-country-picker-modal/lib/FlagButton.js
+@@ -13,7 +13,11 @@ const styles = StyleSheet.create({
+         marginTop: 0,
+     },
+     containerWithoutEmoji: {
+-        marginTop: 5,
++        marginTop: 0,
++        paddingLeft: 20,
++        paddingRight: 20,
++        height: "100%",
++        justifyContent: "center"  
+     },
+     flagWithSomethingContainer: {
+         flexDirection: 'row',

--- a/obi-wallet/patches/react-native-country-picker-modal+2.0.0.patch
+++ b/obi-wallet/patches/react-native-country-picker-modal+2.0.0.patch
@@ -12,6 +12,35 @@ index 4fb16f6..634a958 100644
  });
  //# sourceMappingURL=CloseButton.js.map
 \ No newline at end of file
+diff --git a/node_modules/react-native-country-picker-modal/lib/CountryFilter.js b/node_modules/react-native-country-picker-modal/lib/CountryFilter.js
+index 28b0dc4..0c4f8a5 100644
+--- a/node_modules/react-native-country-picker-modal/lib/CountryFilter.js
++++ b/node_modules/react-native-country-picker-modal/lib/CountryFilter.js
+@@ -1,6 +1,7 @@
+ import React from 'react';
+ import { TextInput, StyleSheet, Platform } from 'react-native';
+ import { useTheme } from './CountryTheme';
++import { useIntl } from 'react-intl';
+ const styles = StyleSheet.create({
+     input: {
+         height: 48,
+@@ -21,8 +22,12 @@ export const CountryFilter = (props) => {
+             { fontFamily, fontSize, color: onBackgroundTextColor }
+         ] }, props)));
+ };
+-CountryFilter.defaultProps = {
+-    autoFocus: false,
+-    placeholder: 'Enter country name'
++ const setCountryLanguage = () => {
++    const intl = useIntl();
++    CountryFilter.defaultProps = {
++        autoFocus: false,
++        placeholder: intl.formatMessage({ id: "phonecountrypicker.search.placeholder", defaultMessage: "Enter country name", })
++    };
+ };
++setCountryLanguage()
+ //# sourceMappingURL=CountryFilter.js.map
+\ No newline at end of file
 diff --git a/node_modules/react-native-country-picker-modal/lib/CountryList.js b/node_modules/react-native-country-picker-modal/lib/CountryList.js
 index 8816018..27c8f1f 100644
 --- a/node_modules/react-native-country-picker-modal/lib/CountryList.js


### PR DESCRIPTION
- Fixed touchable area for phone-country-picker (wasn't covering the small box, just the flag+countrycode was touchable)
- Removed preferred country "US" shown on top of the list, as it is already preselected by default anyway
- Added reactl-intl support for search-field