### PR TITLE
Fix empty social key input

### DIFF
--- a/obi-wallet/apps/mobile/package.json
+++ b/obi-wallet/apps/mobile/package.json
@@ -44,6 +44,7 @@
     "metro-react-native-babel-transformer": "*",
     "mobx": "*",
     "mobx-react-lite": "*",
+    "nanoid": "*",
     "node-html-parser": "*",
     "otplib": "*",
     "process": "*",
@@ -79,7 +80,6 @@
     "react-router": "*",
     "rooks": "*",
     "secp256k1": "*",
-    "tiny-invariant": "*",
-    "nanoid": "*"
+    "tiny-invariant": "*"
   }
 }

--- a/obi-wallet/apps/mobile/package.json
+++ b/obi-wallet/apps/mobile/package.json
@@ -79,6 +79,7 @@
     "react-router": "*",
     "rooks": "*",
     "secp256k1": "*",
-    "tiny-invariant": "*"
+    "tiny-invariant": "*",
+    "nanoid": "*"
   }
 }

--- a/obi-wallet/apps/mobile/src/app/screens/onboarding/common/4-social/index.tsx
+++ b/obi-wallet/apps/mobile/src/app/screens/onboarding/common/4-social/index.tsx
@@ -29,10 +29,24 @@ export const MultisigSocial = observer<MultisigSocialProps>(
     const { chainStore } = useStore();
     const wallet = useMultisigWallet();
     const [address, setAddress] = useState("");
+    const [verifyButtonDisabled, setVerifyButtonDisabled] = useState(true); // Verify&Proceed Button disabled by default
     const [fetchingPubKey, setFetchingPubKey] = useState(false);
     const obi_address = "juno17w77rnps59cnallfskg42s3ntnlhrzu2mjkr3e";
 
     const intl = useIntl();
+
+    const minAddressInputChars = 43;
+
+    useEffect(() => {
+      if (
+        address.length >= minAddressInputChars &&
+        address.startsWith("juno1")
+      ) {
+        setVerifyButtonDisabled(false); // Enable Verify&Proceed Button if checks are okay
+      } else {
+        setVerifyButtonDisabled(true);
+      }
+    }, [verifyButtonDisabled, address]);
 
     useEffect(() => {
       const { social } = wallet.nextAdmin;
@@ -75,8 +89,12 @@ export const MultisigSocial = observer<MultisigSocialProps>(
       } catch (e) {
         console.log(e);
         Alert.alert(
-          "We don’t see any activity for this address.",
-          "Please check the address, tell your friend to use it once (such as sending coins to themselves), or try another address."
+          intl.formatMessage({
+            id: "onboarding5.error.noactivity.title",
+          }),
+          intl.formatMessage({
+            id: "onboarding5.error.noactivity.subtext",
+          })
         );
         return null;
       } finally {
@@ -206,7 +224,9 @@ export const MultisigSocial = observer<MultisigSocialProps>(
             </View>
             <View>
               <VerifyAndProceedButton
-                disabled={fetchingPubKey}
+                disabled={
+                  verifyButtonDisabled ? verifyButtonDisabled : fetchingPubKey
+                }
                 onPress={async () => {
                   setFetchingPubKey(true);
                   const publicKey = await getAccountPubkey(address);

--- a/obi-wallet/libs/common/src/languages/de.json
+++ b/obi-wallet/libs/common/src/languages/de.json
@@ -113,6 +113,8 @@
   "onboarding5.useobiaccount": "Verwende Obi Account",
   "onboarding5.recovery.setsocialkey": "Lege einen neuen Social-Key fest",
   "onboarding5.recovery.setsocialkey.subtext2": "Du verwendest derzeit den Obi-Account. Dies wird den Obi-Account von deiner Multisig entfernen und ihn mit dem Key deines Freundes ersetzen.",
+  "onboarding5.error.noactivity.title": "Wir konnten keine Aktivität unter diese Adresse finden.",
+  "onboarding5.error.noactivity.subtext": "Bitte überprüfe die Adresse, sag deinem Freund er soll sie zumindest einmal verwenden (zum Beispiel indem er Coins an sich selbst schickt), oder versuche eine andere Adresse.",
 
   "onboarding4.error.socialkeyexists.title": "Du hast bereits einen Social-Key",
   "onboarding4.error.socialkeyexists.text": "Möchtest du deinen bestehenden Biometrie-Key wiederverwenden? Für:",

--- a/obi-wallet/libs/common/src/languages/en.json
+++ b/obi-wallet/libs/common/src/languages/en.json
@@ -113,6 +113,8 @@
   "onboarding5.useobiaccount": "Use Obi Account",
   "onboarding5.recovery.setsocialkey": "Set a New Social Key",
   "onboarding5.recovery.setsocialkey.subtext2": "You're currently using the Obi account. This will remove the Obi account from your multisig and replace it with your friend's key.",
+  "onboarding5.error.noactivity.title": "We don't see any activity for this address.",
+  "onboarding5.error.noactivity.subtext": "Please check the address, tell your friend to use it once (such as sending coins to themselves), or try another address.",
 
   "onboarding4.error.socialkeyexists.title": "You already have a social key",
   "onboarding4.error.socialkeyexists.text": "Do you want to reuse your existing social key for",

--- a/obi-wallet/libs/common/src/languages/es.json
+++ b/obi-wallet/libs/common/src/languages/es.json
@@ -114,6 +114,8 @@
   "onboarding5.useobiaccount": "Usar Cuenta Obi",
   "onboarding5.recovery.setsocialkey": "Set a New Social Key",
   "onboarding5.recovery.setsocialkey.subtext2": "You're currently using the Obi account. This will remove the Obi account from your multisig and replace it with your friend's key.",
+  "onboarding5.error.noactivity.title": "We don't see any activity for this address.",
+  "onboarding5.error.noactivity.subtext": "Please check the address, tell your friend to use it once (such as sending coins to themselves), or try another address.",
 
   "onboarding4.error.socialkeyexists.title": "Ya tienes una clave social",
   "onboarding4.error.socialkeyexists.text": "¿Deseas reutilizar tu clave social existente para",


### PR DESCRIPTION
It was possible to press the Verify&Proceed-Button with an empty input, ending up with the alert:

_"We don't see any activity for this address. Please check the address, tell your friend to use it once (such as sending coins to themselves), or try another address."_

![Screenshot 2022-10-20 at 13 27 44](https://user-images.githubusercontent.com/99530800/196946615-01dc91e0-f174-49ff-ada8-8d7a7af26b2c.png)


**Changes:**
- Disabled Social-Key-Button by default
- Added checks to enable Button (minCharLength + address must begin with "juno1")
- Added React Intl translations