### PR TITLE
Fix Assets/Swipe-Down-To-Refresh-Color

### DIFF
--- a/obi-wallet/apps/mobile/src/app/screens/components/connected-web-view/index.tsx
+++ b/obi-wallet/apps/mobile/src/app/screens/components/connected-web-view/index.tsx
@@ -83,6 +83,7 @@ export const ConnectedWebView = observer(
               webViewRef.current?.reload();
               setLoading(true);
             }}
+            tintColor="rgba(246, 245, 255, 0.6)"
           />
         }
       >

--- a/obi-wallet/apps/mobile/src/app/screens/home/components/assets.tsx
+++ b/obi-wallet/apps/mobile/src/app/screens/home/components/assets.tsx
@@ -444,6 +444,7 @@ const AssetsList = observer(() => {
             <RefreshControl
               refreshing={refreshing}
               onRefresh={refreshBalances}
+              tintColor="white"
             />
           }
         />

--- a/obi-wallet/apps/mobile/src/app/screens/home/components/assets.tsx
+++ b/obi-wallet/apps/mobile/src/app/screens/home/components/assets.tsx
@@ -444,7 +444,7 @@ const AssetsList = observer(() => {
             <RefreshControl
               refreshing={refreshing}
               onRefresh={refreshBalances}
-              tintColor="white"
+              tintColor="rgba(246, 245, 255, 0.6)"
             />
           }
         />
@@ -562,7 +562,7 @@ function AssetsListItem({ item }: ListRenderItemInfo<ExtendedCoin>) {
 
           <Text
             style={{
-              color: "rgba(246, 245, 255, 0.6);",
+              color: "rgba(246, 245, 255, 0.6)",
               fontSize: 12,
               fontWeight: "400",
               textAlign: "right",

--- a/obi-wallet/apps/mobile/src/app/screens/send/index.tsx
+++ b/obi-wallet/apps/mobile/src/app/screens/send/index.tsx
@@ -510,6 +510,7 @@ export const SendScreen = observer(() => {
                 <RefreshControl
                   refreshing={refreshing}
                   onRefresh={refreshBalances}
+                  tintColor="rgba(246, 245, 255, 0.6)"
                 />
               }
             />


### PR DESCRIPTION
Swipe-Down to refresh assets => the Activity-Indicator was invisible or probably had the same color than the background

<img width="800" alt="Screenshot 2022-10-21 at 17 45 06" src="https://user-images.githubusercontent.com/99530800/197236291-d202c34a-b8ab-48e1-a07b-b3e03f825df8.png">
